### PR TITLE
fix: display group type names instead of IDs in automatic groups

### DIFF
--- a/src/components/automatic-groups/AutomaticGroupsAdmin.vue
+++ b/src/components/automatic-groups/AutomaticGroupsAdmin.vue
@@ -10,7 +10,7 @@
     description="Überwachung und Verwaltung aller automatischen Gruppen"
     searchable
     search-placeholder="Gruppen durchsuchen..."
-    :search-fields="['name', 'groupTypeId']"
+    :search-fields="['name', 'groupTypeName']"
     default-sort-field="id"
     loading-text="Lade automatische Gruppen..."
     empty-text="Keine automatischen Gruppen gefunden."
@@ -83,7 +83,7 @@ const adminTableRef = ref()
 // Table configuration
 const tableColumns: TableColumn[] = [
   { key: 'id', label: 'Gruppen-ID', sortable: true, resizable: true, width: 100 },
-  { key: 'groupTypeId', label: 'Gruppentyp', sortable: true, resizable: true, width: 120 },
+  { key: 'groupTypeName', label: 'Gruppentyp', sortable: true, resizable: true, width: 120 },
   {
     key: 'name',
     label: 'Name',

--- a/src/composables/useAutomaticGroups.ts
+++ b/src/composables/useAutomaticGroups.ts
@@ -4,7 +4,8 @@ import { churchtoolsClient } from '@churchtools/churchtools-client'
 export interface AutomaticGroup {
   id: number
   name: string
-  groupTypeId?: string
+  groupTypeId: number
+  groupTypeName: string
   dynamicGroupStatus: string
   lastExecution: string | null
   executionStatus: 'success' | 'error' | 'running' | 'pending' | 'unknown'
@@ -29,6 +30,36 @@ function determineExecutionStatus(group: any): AutomaticGroup['executionStatus']
 }
 
 async function fetchAutomaticGroups(): Promise<AutomaticGroup[]> {
+  // First, fetch all group types to create a mapping
+  let groupTypeMap = new Map<number, string>()
+
+  try {
+    const groupTypesResponse = await churchtoolsClient.get('/group/grouptypes')
+
+    // Handle different response structures
+    let groupTypes: any[] = []
+    if (
+      groupTypesResponse &&
+      (groupTypesResponse as any).data &&
+      Array.isArray((groupTypesResponse as any).data)
+    ) {
+      groupTypes = (groupTypesResponse as any).data
+    } else if (Array.isArray(groupTypesResponse)) {
+      groupTypes = groupTypesResponse
+    } else {
+      console.warn('Unexpected group types response structure:', groupTypesResponse)
+    }
+
+    groupTypes.forEach((groupType: any) => {
+      if (groupType.id && groupType.name) {
+        groupTypeMap.set(groupType.id, groupType.name)
+      }
+    })
+  } catch (error) {
+    console.warn('Failed to fetch group types:', error)
+    // Continue without group type mapping
+  }
+
   let allGroups: any[] = []
   let page = 1
   const limit = 100
@@ -37,16 +68,16 @@ async function fetchAutomaticGroups(): Promise<AutomaticGroup[]> {
   // Fetch all groups with proper pagination
   while (hasMore) {
     const response = await churchtoolsClient.get(
-      `/groups?include=settings&limit=${limit}&page=${page}`
+      `/groups?include=settings,domainAttributes&limit=${limit}&page=${page}`
     )
 
     let pageGroups: any[] = []
-    if (Array.isArray(response)) {
-      pageGroups = response
-    } else if (response && (response as any).data && Array.isArray((response as any).data)) {
+    if (response && (response as any).data && Array.isArray((response as any).data)) {
       pageGroups = (response as any).data
-    } else if (response && Array.isArray((response as any).groups)) {
-      pageGroups = (response as any).groups
+    } else if (Array.isArray(response)) {
+      pageGroups = response
+    } else {
+      console.warn('Unexpected groups response structure:', response)
     }
 
     if (pageGroups.length === 0) {
@@ -70,16 +101,28 @@ async function fetchAutomaticGroups(): Promise<AutomaticGroup[]> {
         group.settings.dynamicGroupStatus !== 'none' &&
         group.settings.dynamicGroupStatus !== null
     )
-    .map((group) => ({
-      id: group.id,
-      name: group.name || `Gruppe ${group.id}`,
-      groupTypeId: group.groupTypeId || group.groupType?.name || 'N/A',
-      dynamicGroupStatus: group.settings?.dynamicGroupStatus || 'none',
-      lastExecution: group.settings?.dynamicGroupUpdateFinished || null,
-      executionStatus: determineExecutionStatus(group),
-      dynamicGroupUpdateStarted: group.settings?.dynamicGroupUpdateStarted || null,
-      dynamicGroupUpdateFinished: group.settings?.dynamicGroupUpdateFinished || null,
-    }))
+    .map((group) => {
+      // Try different possible locations for groupTypeId
+      const groupTypeId =
+        group.information?.groupTypeId ||
+        group.domainAttributes?.groupTypeId ||
+        group.groupTypeId ||
+        0
+
+      const groupTypeName = groupTypeMap.get(groupTypeId) || 'Unbekannter Typ'
+
+      return {
+        id: group.id,
+        name: group.name || `Gruppe ${group.id}`,
+        groupTypeId,
+        groupTypeName,
+        dynamicGroupStatus: group.settings?.dynamicGroupStatus || 'none',
+        lastExecution: group.settings?.dynamicGroupUpdateFinished || null,
+        executionStatus: determineExecutionStatus(group),
+        dynamicGroupUpdateStarted: group.settings?.dynamicGroupUpdateStarted || null,
+        dynamicGroupUpdateFinished: group.settings?.dynamicGroupUpdateFinished || null,
+      }
+    })
 
   return automaticGroups
 }


### PR DESCRIPTION
## Problem

Automatic groups were displaying 'Unbekannter Typ' instead of actual group type names like 'Hauskreis', 'Mitarbeiterteam', etc.

## Root Cause

- Group type ID was being accessed from wrong field path
- No mapping from group type IDs to human-readable names
- API response structure was not properly handled

## Solution

- **Fetch group types**: Added API call to /group/grouptypes to create ID-to-name mapping
- **Correct field access**: Access groupTypeId from group.information.groupTypeId (not root level)
- **Robust API handling**: Handle both data array and direct array responses
- **Interface updates**: Added both groupTypeId (number) and groupTypeName (string) fields
- **UI improvements**: Display groupTypeName instead of groupTypeId in admin table

## Technical Details

### API Integration
- Fetch group types upfront and create Map for efficient lookups
- Include domainAttributes in groups API call for complete data
- Robust error handling with fallbacks

### Field Access Priority
1. group.information.groupTypeId (correct path)
2. group.domainAttributes.groupTypeId (fallback)
3. group.groupTypeId (fallback)
4. 0 (default)

## Files Changed

- src/composables/useAutomaticGroups.ts - Core logic for fetching and mapping group types
- src/components/automatic-groups/AutomaticGroupsAdmin.vue - UI updates for displaying group type names

## Testing

- Group types are correctly fetched and mapped
- Automatic groups now display readable group type names
- Error handling works when group types API fails
- All lint checks pass
- No breaking changes to existing functionality

## Documentation

- Complete session documentation created
- Lessons learned updated with ChurchTools API patterns
- Reusable pattern for other ID-to-name mappings

Resolves the grouptype display issue and provides a robust foundation for similar reference data mappings.