### PR TITLE
refactor: Swap card button order - Details as primary action

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "churchtools-dashboard",
-  "version": "1.0.7",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "churchtools-dashboard",
-      "version": "1.0.7",
+      "version": "1.0.9",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^7.0.1",
         "@fortawesome/free-solid-svg-icons": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "churchtools-dashboard",
   "private": true,
-  "version": "1.0.8",
+  "version": "1.0.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/common/BaseCard.vue
+++ b/src/components/common/BaseCard.vue
@@ -81,24 +81,24 @@
           <template v-else>&nbsp;</template>
         </span>
         <div class="footer-actions">
-          <slot name="actions">
-            <button
-              type="button"
-              @click="$emit('navigate')"
-              class="ct-btn ct-btn-sm ct-btn-outline"
-            >
-              {{ detailsText }}
-            </button>
-          </slot>
           <button
             type="button"
             @click="$emit('refresh')"
-            class="ct-btn ct-btn-primary ct-btn-sm"
+            class="ct-btn ct-btn-secondary ct-btn-sm"
             :disabled="isLoading"
           >
             <span v-if="isLoading" class="btn-spinner"></span>
             {{ isLoading ? refreshingText : refreshText }}
           </button>
+          <slot name="actions">
+            <button
+              type="button"
+              @click="$emit('navigate')"
+              class="ct-btn ct-btn-primary ct-btn-sm"
+            >
+              {{ detailsText }}
+            </button>
+          </slot>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Swaps the button order on dashboard cards to make Details the primary action.

## Changes

- ✅ Move Refresh button to left (secondary/gray style)
- ✅ Move Details button to right (primary/blue style)
- ✅ Makes Details the default/primary action on cards
- ✅ Version bump to 1.0.9

## Rationale

Details is the more common user action on cards, so it should be the primary (blue) button on the right side, following common UI patterns where the primary action is positioned on the right.

## Visual Changes

**Before:**
- Left: Details (outline/gray)
- Right: Refresh (primary/blue)

**After:**
- Left: Refresh (secondary/gray)
- Right: Details (primary/blue)

## Testing

- ✅ All changes pass `npm run lint`
- ✅ Verified button order and styling on cards

Co-authored-by: Ona <no-reply@ona.com>